### PR TITLE
📦 feat(frontend): add getHealth() helper for health‑check

### DIFF
--- a/frontend/src/api/health.js
+++ b/frontend/src/api/health.js
@@ -12,3 +12,25 @@ export async function getHealth() {
   }
   return res.json();
 }
+
+
+// frontend/src/api/health.js
+
+/**
+ * Fetches the backend health-check endpoint.
+ * @returns {Promise<{status: string, service: string}>}
+ * @throws {Error} if the response status is not OK.
+ */
+export async function getHealth() {
+  // The base URL is injected by Vite from your .env (VITE_API_URL=http://localhost:5000)
+  const base = import.meta.env.VITE_API_URL;
+  const res = await fetch(`${base}/health`);
+
+  if (!res.ok) {
+    // Forward HTTP error for caller to catch
+    throw new Error(res.statusText || `HTTP ${res.status}`);
+  }
+
+  // Parse and return JSON payload
+  return res.json();
+}


### PR DESCRIPTION
Closes #1 

This adds `getHealth()` in `frontend/src/api/health.js` which:
- Reads the backend base URL from `import.meta.env.VITE_API_URL`
- Sends a GET to `/health`
- Throws on non‑OK responses
- Returns the parsed JSON `{ status, service }`

Verified manually in App.jsx via useEffect showing “Backend status: healthy”.
