### PR TITLE
feat(frontend): fetch health via Redux thunk

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -5,12 +5,14 @@ from .routes.auth import auth
 from .routes.posts import posts
 from .routes.oauth import oauth
 from .routes.analytics import analytics
+from .routes.health import health_bp
 
 def create_app():
     app = Flask(__name__)
 
-    # Enable CORS on all /api/* endpoints from any origin (for dev)
-    CORS(app, resources={r"/api/*": {"origins": "*"}})
+    # Allow cross‑origin requests (for development)
+    CORS(app, resources={r"/*": {"origins": "http://localhost:3000"}})
+
 
     # Health check
     @app.route('/api/health')
@@ -22,5 +24,6 @@ def create_app():
     app.register_blueprint(posts, url_prefix="/api")
     app.register_blueprint(oauth, url_prefix="/api")
     app.register_blueprint(analytics, url_prefix="/api")
+    app.register_blueprint(health_bp, url_prefix='/api')
 
     return app

--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -1,0 +1,13 @@
+from flask import Blueprint, jsonify
+
+health_bp = Blueprint('health', __name__)
+
+@health_bp.route('/health', methods=['GET'])
+def health_check():
+    """
+    Health-check endpoint returning a JSON payload.
+    """
+    return jsonify({
+        'status': 'healthy',
+        'service': 'social-media-dashboard'
+    }), 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - backend
     environment:
-      - VITE_API_URL=http://localhost:5000
+      - VITE_API_URL=http://backend:5000
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - backend
     environment:
-      - REACT_APP_API_URL=http://localhost:5000
+      - VITE_API_URL=http://localhost:5000
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/src/api/health.js
+++ b/frontend/src/api/health.js
@@ -4,8 +4,8 @@
  * @throws {Error} if the response status is not OK.
  */
 export async function getHealth() {
-const res = await fetch(`${import.meta.env.VITE_API_URL}/api/health`);
-
+  // hit the relative URL; Vite will forward it
+  const res = await fetch("/api/health");
   if (!res.ok) {
     // Forward HTTP error for caller to catch
     throw new Error(res.statusText || `HTTP ${res.status}`);

--- a/frontend/src/api/health.js
+++ b/frontend/src/api/health.js
@@ -1,30 +1,10 @@
-// frontend/src/api/health.js
-
-/**
- * Fetches the backend health‑check.
- * @returns {Promise<{status: string, service: string}>}
- * @throws if the network request fails.
- */
-export async function getHealth() {
-  const res = await fetch('http://localhost:5000/api/health');
-  if (!res.ok) {
-    throw new Error(`Health check failed: ${res.status}`);
-  }
-  return res.json();
-}
-
-
-// frontend/src/api/health.js
-
 /**
  * Fetches the backend health-check endpoint.
  * @returns {Promise<{status: string, service: string}>}
  * @throws {Error} if the response status is not OK.
  */
 export async function getHealth() {
-  // The base URL is injected by Vite from your .env (VITE_API_URL=http://localhost:5000)
-  const base = import.meta.env.VITE_API_URL;
-  const res = await fetch(`${base}/health`);
+const res = await fetch(`${import.meta.env.VITE_API_URL}/api/health`);
 
   if (!res.ok) {
     // Forward HTTP error for caller to catch

--- a/frontend/src/features/health/healthSlice.js
+++ b/frontend/src/features/health/healthSlice.js
@@ -1,0 +1,49 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { getHealth } from '../../api/health';
+
+// Async thunk action to fetch health
+export const fetchHealth = createAsyncThunk(
+  'health/fetchHealth',
+  async (_, { rejectWithValue }) => {
+    try {
+      const data = await getHealth();
+      return data; // { status, service }
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+const healthSlice = createSlice({
+  name: 'health',
+  initialState: {
+    loading: false,
+    status: null,
+    service: null,
+    error: null,
+  },
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchHealth.pending, state => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchHealth.fulfilled, (state, action) => {
+        state.loading = false;
+        state.status = action.payload.status;
+        state.service = action.payload.service;
+      })
+      .addCase(fetchHealth.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload || action.error.message;
+      });
+  },
+});
+
+export default healthSlice.reducer;
+
+// Selectors
+export const selectHealthLoading = state => state.health.loading;
+export const selectHealthStatus  = state => state.health.status;
+export const selectHealthError   = state => state.health.error;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,14 +1,18 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    host: '0.0.0.0',
-    port: 3000,
-    watch: {
-      usePolling: true
-    }
-  }
-});
+    host: true,
+    port: 3000,            // your front‑end port
+    proxy: {
+      // any request to /api/* will be forwarded to the backend container
+      '/api': {
+        target: 'http://backend:5000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
+})


### PR DESCRIPTION
Closes #5

- Adds a Redux thunk `fetchHealth()` that calls GET /api/health
- Dispatches `{ status, service }` into slice under `health`
- Renders loading/healthy/error in App.jsx