### PR TITLE
feat(backend): add mock POST /api/auth/login endpoint (#11)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -20,7 +20,7 @@ def create_app():
         return jsonify(status="healthy", service="social-media-dashboard")
 
     # Register your blueprints
-    app.register_blueprint(auth, url_prefix="/api")
+    app.register_blueprint(auth, url_prefix="/api/auth")
     app.register_blueprint(posts, url_prefix="/api")
     app.register_blueprint(oauth, url_prefix="/api")
     app.register_blueprint(analytics, url_prefix="/api")

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,15 +1,36 @@
 from flask import Blueprint, request, jsonify
+from uuid import uuid4
 
-auth = Blueprint('auth', __name__)
+auth = Blueprint("auth", __name__)
 
-@auth.route('/login', methods=['POST'])
+@auth.route("/login", methods=["POST"])
 def login():
-    data = request.json
-    # Add your login logic here
-    return jsonify({"message": "Login successful"}), 200
+    """
+    Minimal mock login endpoint for early development.
 
-@auth.route('/register', methods=['POST'])
+    Expects JSON: { "email": "...", "password": "..." }  (password ignored)
+    Returns: { "token": "<uuid>", "user": { "email": "...", "id": 1 } }
+    """
+    data = request.get_json(silent=True) or {}
+    email = data.get("email")
+    # password = data.get("password")  # ignored for now
+
+    if not email:
+        return jsonify(error="email is required"), 400
+
+    token = uuid4().hex  # placeholder until real JWT
+
+    return jsonify(
+        token=token,
+        user={"email": email, "id": 1},
+    ), 200
+
+
+@auth.route("/register", methods=["POST"])
 def register():
-    data = request.json
-    # Add your registration logic here
-    return jsonify({"message": "User registered"}), 201
+    """
+    Placeholder registration route.
+    """
+    data = request.get_json(silent=True) or {}
+    # Add real registration logic later.
+    return jsonify(message="User registered", received=data), 201


### PR DESCRIPTION
Implements a minimal login endpoint to support early frontend auth flow. 

**Endpoint**
`POST /api/auth/login`

**Request JSON**
```json
{
  "email": "user@example.com",
  "password": "string"  // currently ignored
}
```
Response (200 OK)
```json
{
  "token": "<dummy-token>",
  "user": {
    "email": "user@example.com",
    "id": 1
  }
}
```
Behavior

Accepts any email/password (no validation yet).

Generates a random token (uuid4 hex).

Returns JSON above.

400 if request body missing or not JSON.

CORS works for http://localhost:3000.

Testing

```bash
curl -i -X POST \
  -H "Content-Type: application/json" \
  -d '{"email":"me@test.com","password":"x"}' \
  http://localhost:5000/api/auth/login
```
Closes #11.